### PR TITLE
Add a few minor "extras"

### DIFF
--- a/handbrake.sh
+++ b/handbrake.sh
@@ -17,5 +17,5 @@ do
 #
         $HANDBRAKE_CLI --all-audio --all-subtitles -i "$SRC/$FILE" -o "$DEST/$filename.$DEST_EXT" --preset="$PRESET"
         $TOUCH -r "$SRC/$FILE" "$DEST/$filename.$DEST_EXT"
-        #rm -rf $SRC/$FILE
+        #rm -rf "$SRC/$FILE"
 done

--- a/handbrake.sh
+++ b/handbrake.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+TOUCH=touch
 SRC=/data/mediaserver/Handbrake/RAW/
 DEST=/data/mediaserver/Handbrake/Post/
 DEST_EXT=mkv
@@ -14,5 +15,6 @@ do
         extension=${filename##*.}
         filename=${filename%.*}
 #
-        $HANDBRAKE_CLI --all-audio --all-subtitles -i $SRC/$FILE -o $DEST/$filename.$DEST_EXT --preset="$PRESET"
+        $HANDBRAKE_CLI --all-audio --all-subtitles -i "$SRC/$FILE" -o "$DEST/$filename.$DEST_EXT" --preset="$PRESET"
+        $TOUCH -r "$SRC/$FILE" "$DEST/$filename.$DEST_EXT"
 done

--- a/handbrake.sh
+++ b/handbrake.sh
@@ -17,4 +17,5 @@ do
 #
         $HANDBRAKE_CLI --all-audio --all-subtitles -i "$SRC/$FILE" -o "$DEST/$filename.$DEST_EXT" --preset="$PRESET"
         $TOUCH -r "$SRC/$FILE" "$DEST/$filename.$DEST_EXT"
+        #rm -rf $SRC/$FILE
 done


### PR DESCRIPTION
Add and make use of the Unix/Linux "touch" command to preserve the input file's filesystem timestamp on the output file's filesystem timestamp (overwrite the output file's filesystem timestamp with the one copied from the input file), along with an optional delete function (commented out so not active by default), and add quotations in cases/scenarios where there are spaces in filenames.